### PR TITLE
Prune keywords in packages

### DIFF
--- a/branding/package.json
+++ b/branding/package.json
@@ -18,8 +18,6 @@
         "Brightlayer-UI",
         "colors",
         "Eaton",
-        "Power",
-        "Xpert",
         "quality",
         "lighting"
     ],

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,8 +18,6 @@
         "Brightlayer-UI",
         "colors",
         "Eaton",
-        "Power",
-        "Xpert",
         "quality",
         "lighting"
     ],


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove `Power` & `Xpert` from package keywords
