### PR TITLE
Update Types used in the Colors-Branding package

### DIFF
--- a/branding/CHANGELOG.md
+++ b/branding/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v3.2.0 (Not yet published)
+
+### Updated
+
+-   Updated palette type definition to use `@brightlayer-ui/types@2.0.0`.
+
 ## v3.1.0 (October 20, 2021)
 
 ### Changed

--- a/branding/package.json
+++ b/branding/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/colors-branding",
-    "version": "3.1.0",
+    "version": "3.2.0-beta.0",
     "description": "Eaton Branding colors for Eaton applications",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     },
     "homepage": "https://github.com/brightlayer-ui/colors#readme",
     "dependencies": {
-        "@brightlayer-ui/types": "^1.0.0"
+        "@brightlayer-ui/types": "^2.0.0"
     },
     "devDependencies": {
         "typescript": "^3.7.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #38 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use latest type defs in the colors-branding package.
-  Migrating from `types@^1.0.0` & `@types@^2.0.0` is a non-breaking change for the colors-branding package. 

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `cd branding && yarn && yarn build`
