### PR TITLE
Include CommonJS & ES2015 Module

### DIFF
--- a/branding/CHANGELOG.md
+++ b/branding/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v3.2.1 (Not yet published)
+
+### Changed
+
+- Reverted change from version `3.2.0` & default added a `es2015` build option.
+
 ## v3.2.0 (April 15, 2022)
 
 ### Changed

--- a/branding/package.json
+++ b/branding/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@brightlayer-ui/colors-branding",
-    "version": "3.2.0",
+    "version": "3.2.1-beta.0",
     "description": "Eaton Branding colors for Eaton applications",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./dist/commonjs/index.js",
+    "types": "./dist/commonjs/index.d.ts",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "build": "yarn && tsc",
+        "build": "yarn && tsc --module commonjs --outDir dist/commonjs && tsc --module ES2015 --outDir dist/es2015",
         "publish:package": "set npm_config_yes=true && npx -p @brightlayer-ui/publish blui-publish",
         "tag:package": "npx -p @brightlayer-ui/tag blui-tag"
     },

--- a/buildTest.sh
+++ b/buildTest.sh
@@ -6,13 +6,13 @@ NC='\033[0m' # No Color
 
 echo "Checking for required files..."
 echo -ne "  UI index.js: "
-if [ ! -f ./ui/dist/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./ui/dist/commonjs/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI index.d.ts "
-if [ ! -f ./ui/dist/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./ui/dist/commonjs/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI palette.js: "
-if [ ! -f ./ui/dist/palette.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./ui/dist/commonjs/palette.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI palette.d.ts "
-if [ ! -f ./ui/dist/palette.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./ui/dist/commonjs/palette.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI package.json: "
 if [ ! -f ./ui/package.json ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI README: "
@@ -24,13 +24,13 @@ if [ ! -f ./ui/LICENSES.json ]; then echo -e "${RED}Not Found${NC}" && exit 1; e
 
 
 echo -ne "  Branding index.js: "
-if [ ! -f ./branding/dist/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./branding/dist/commonjs/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Branding index.d.ts "
-if [ ! -f ./branding/dist/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./branding/dist/commonjs/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI palette.js: "
-if [ ! -f ./branding/dist/palette.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./branding/dist/commonjs/palette.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  UI palette.d.ts "
-if [ ! -f ./branding/dist/palette.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./branding/dist/commonjs/palette.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Branding package.json: "
 if [ ! -f ./branding/package.json ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Branding README: "

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v3.1.1 (Not yet published)
+
+### Changed
+
+- Reverted change from version `3.1.0` & default added a `es2015` build option.
+
 ## v3.1.0 (April 15, 2022)
 
 ### Added

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@brightlayer-ui/colors",
-    "version": "3.1.0",
+    "version": "3.1.1-beta.0",
     "description": "Brightlayer UI colors for Eaton applications",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
+    "main": "./dist/commonjs/index.js",
+    "types": "./dist/commonjs/index.d.ts",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "build": "yarn && tsc",
+        "build": "yarn && tsc --module commonjs --outDir dist/commonjs && tsc --module ES2015 --outDir dist/es2015",
         "publish:package": "set npm_config_yes=true && npx -p @brightlayer-ui/publish blui-publish",
         "tag:package": "npx -p @brightlayer-ui/tag blui-tag"
     },


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  Reverts the change from #47; instead of distributing the package with no commonjs module & only a es2015 module, now the package includes the original commonjs module as the default & an alternative es2015 built module.

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- We can test it in the beta packages, or build local & copy into a showcase's node_modules folder. 
